### PR TITLE
Fix desynced sizing

### DIFF
--- a/src/libANGLE/renderer/d3d/SurfaceD3D.cpp
+++ b/src/libANGLE/renderer/d3d/SurfaceD3D.cpp
@@ -241,8 +241,8 @@ egl::Error SurfaceD3D::resizeSwapChain(DisplayD3D *displayD3D,
         return egl::Error(status);
     }
 
-    mWidth  = backbufferWidth;
-    mHeight = backbufferHeight;
+    mWidth  = mSwapChain->getWidth();
+    mHeight = mSwapChain->getHeight();
 
     return egl::NoError();
 }
@@ -267,8 +267,8 @@ egl::Error SurfaceD3D::resetSwapChain(DisplayD3D *displayD3D,
         return egl::Error(status);
     }
 
-    mWidth             = backbufferWidth;
-    mHeight            = backbufferHeight;
+    mWidth             = mSwapChain->getWidth();
+    mHeight            = mSwapChain->getHeight();
     mSwapIntervalDirty = false;
 
     return egl::NoError();
@@ -359,7 +359,7 @@ egl::Error SurfaceD3D::checkForOutOfDateSwapChain(DisplayD3D *displayD3D)
 egl::Error SurfaceD3D::toggleWindowed(DisplayD3D *displayD3D)
 {
     ANGLE_TRY(mSwapChain->toggleWindowed());
-    ANGLE_TRY(resetSwapChain(displayD3D, mWidth, mHeight));
+    ANGLE_TRY(resetSwapChain(displayD3D, mSwapChain->getWidth(), mSwapChain->getHeight()));
 
     return egl::NoError();
 }

--- a/src/libANGLE/renderer/d3d/SwapChainD3D.h
+++ b/src/libANGLE/renderer/d3d/SwapChainD3D.h
@@ -71,6 +71,8 @@ class SwapChainD3D : angle::NonCopyable
 
     virtual egl::Error getSyncValues(EGLuint64KHR *ust, EGLuint64KHR *msc, EGLuint64KHR *sbc) = 0;
 
+    virtual EGLint getWidth() const  = 0;
+    virtual EGLint getHeight() const = 0;
     virtual egl::Error toggleWindowed() { return egl::NoError(); }
     virtual EGLBoolean getWindowed() { return EGL_TRUE; }
     virtual int getTargetWidth() { return 0; }

--- a/src/libANGLE/renderer/d3d/d3d11/SwapChain11.h
+++ b/src/libANGLE/renderer/d3d/d3d11/SwapChain11.h
@@ -54,8 +54,8 @@ class SwapChain11 final : public SwapChainD3D
     const d3d11::DepthStencilView &getDepthStencil();
     const d3d11::SharedSRV &getDepthStencilShaderResource();
 
-    EGLint getWidth() const { return mWidth; }
-    EGLint getHeight() const { return mHeight; }
+    EGLint getWidth() const override { return mWidth; }
+    EGLint getHeight() const override { return mHeight; }
     void *getKeyedMutex() override;
     EGLint getSamples() const { return mEGLSamples; }
 

--- a/src/libANGLE/renderer/d3d/d3d9/SwapChain9.cpp
+++ b/src/libANGLE/renderer/d3d/d3d9/SwapChain9.cpp
@@ -269,14 +269,14 @@ EGLint SwapChain9::reset(DisplayD3D *displayD3D,
     {
         RECT rect = {0, 0, mWidth, mHeight};
 
-        if (rect.right > static_cast<LONG>(backbufferWidth))
+        if (rect.right > static_cast<LONG>(presentParameters.BackBufferWidth))
         {
-            rect.right = backbufferWidth;
+            rect.right = presentParameters.BackBufferWidth;
         }
 
-        if (rect.bottom > static_cast<LONG>(backbufferHeight))
+        if (rect.bottom > static_cast<LONG>(presentParameters.BackBufferHeight))
         {
-            rect.bottom = backbufferHeight;
+            rect.bottom = presentParameters.BackBufferHeight;
         }
 
         mRenderer->endScene();

--- a/src/libANGLE/renderer/d3d/d3d9/SwapChain9.cpp
+++ b/src/libANGLE/renderer/d3d/d3d9/SwapChain9.cpp
@@ -380,7 +380,7 @@ EGLint SwapChain9::swapRect(DisplayD3D *displayD3D, EGLint x, EGLint y, EGLint w
     RECT rect = {static_cast<LONG>(x), static_cast<LONG>(mHeight - y - height),
                  static_cast<LONG>(x + width), static_cast<LONG>(mHeight - y)};
 
-    HRESULT result = mSwapChain->Present(nullptr, nullptr, nullptr, nullptr, 0);
+    HRESULT result = mSwapChain->Present(&rect, &rect, nullptr, nullptr, 0);
 
     mRenderer->markAllStateDirty();
 

--- a/src/libANGLE/renderer/d3d/d3d9/SwapChain9.h
+++ b/src/libANGLE/renderer/d3d/d3d9/SwapChain9.h
@@ -49,8 +49,8 @@ class SwapChain9 : public SwapChainD3D
     virtual IDirect3DSurface9 *getDepthStencil();
     virtual IDirect3DTexture9 *getOffscreenTexture();
 
-    EGLint getWidth() const { return mWidth; }
-    EGLint getHeight() const { return mHeight; }
+    EGLint getWidth() const override { return mWidth; }
+    EGLint getHeight() const override { return mHeight; }
 
     void *getKeyedMutex() override;
 


### PR DESCRIPTION
1. `SwapChain9` locally overrides the given size with a potentially fullscreen one. This also needs to be set as the stored sizings of `SurfaceD3D`. The old ANGLE only stored the one from `resetSwapChain`, but I think the one in `resizeSwapChain` is also required.
2. Along a similar note, `SwapChain9::reset()` may not resize the render target correctly. This would've been an issue with the old ANGLE too.
3. The presentation rectangle was removed to follow the old ANGLE's footsteps. This directly fixed the black bars on my test setups.

All of the above could cause black screens, but not 100%.