### PR TITLE
Fix blackness when fullscreened + windowed black bar

### DIFF
--- a/src/libANGLE/renderer/d3d/d3d9/SwapChain9.cpp
+++ b/src/libANGLE/renderer/d3d/d3d9/SwapChain9.cpp
@@ -377,10 +377,7 @@ EGLint SwapChain9::swapRect(DisplayD3D *displayD3D, EGLint x, EGLint y, EGLint w
 
     device->SetTexture(0, nullptr);
 
-    RECT rect = {static_cast<LONG>(x), static_cast<LONG>(mHeight - y - height),
-                 static_cast<LONG>(x + width), static_cast<LONG>(mHeight - y)};
-
-    HRESULT result = mSwapChain->Present(&rect, &rect, nullptr, nullptr, 0);
+    HRESULT result = device->Present(nullptr, nullptr, nullptr, nullptr);
 
     mRenderer->markAllStateDirty();
 

--- a/src/libANGLE/renderer/d3d/d3d9/SwapChain9.cpp
+++ b/src/libANGLE/renderer/d3d/d3d9/SwapChain9.cpp
@@ -379,7 +379,21 @@ EGLint SwapChain9::swapRect(DisplayD3D *displayD3D, EGLint x, EGLint y, EGLint w
 
     device->SetTexture(0, nullptr);
 
-    HRESULT result = device->Present(nullptr, nullptr, nullptr, nullptr);
+    HRESULT result;
+
+    if (mWindowed)
+    {
+        RECT rect = {static_cast<LONG>(x), static_cast<LONG>(mHeight - y - height),
+                     static_cast<LONG>(x + width), static_cast<LONG>(mHeight - y)};
+
+        result = mSwapChain->Present(&rect, &rect, nullptr, nullptr, 0);
+    }
+    else
+    {
+        // On some devices, presenting the swapchain in fullscreen mode results in a black screen.
+        // The src/dst rects also cause issues like minimisation.
+        result = device->Present(nullptr, nullptr, nullptr, nullptr);
+    }
 
     mRenderer->markAllStateDirty();
 

--- a/src/libANGLE/renderer/d3d/d3d9/SwapChain9.cpp
+++ b/src/libANGLE/renderer/d3d/d3d9/SwapChain9.cpp
@@ -142,9 +142,12 @@ EGLint SwapChain9::reset(DisplayD3D *displayD3D,
         // Fullscreen
         D3DDISPLAYMODE displayMode = getDisplayMode();
 
+        backbufferWidth  = displayMode.Width;
+        backbufferHeight = displayMode.Height;
+
         presentParameters.Windowed                   = FALSE;
-        presentParameters.BackBufferWidth            = displayMode.Width;
-        presentParameters.BackBufferHeight           = displayMode.Height;
+        presentParameters.BackBufferWidth            = backbufferWidth;
+        presentParameters.BackBufferHeight           = backbufferHeight;
         presentParameters.FullScreen_RefreshRateInHz = displayMode.RefreshRate;
     }
     else
@@ -242,9 +245,8 @@ EGLint SwapChain9::reset(DisplayD3D *displayD3D,
         pShareHandle = &mShareHandle;
 
     HRESULT result = mRenderer->getDevice()->CreateTexture(
-        presentParameters.BackBufferWidth, presentParameters.BackBufferHeight, 1,
-        D3DUSAGE_RENDERTARGET, backBuffered3dFormatInfo.texFormat, D3DPOOL_DEFAULT,
-        &mOffscreenTexture, pShareHandle);
+        backbufferWidth, backbufferHeight, 1, D3DUSAGE_RENDERTARGET,
+        backBuffered3dFormatInfo.texFormat, D3DPOOL_DEFAULT, &mOffscreenTexture, pShareHandle);
     if (FAILED(result))
     {
         ERR() << "Could not create offscreen texture, " << gl::FmtHR(result);
@@ -269,14 +271,14 @@ EGLint SwapChain9::reset(DisplayD3D *displayD3D,
     {
         RECT rect = {0, 0, mWidth, mHeight};
 
-        if (rect.right > static_cast<LONG>(presentParameters.BackBufferWidth))
+        if (rect.right > static_cast<LONG>(backbufferWidth))
         {
-            rect.right = presentParameters.BackBufferWidth;
+            rect.right = backbufferWidth;
         }
 
-        if (rect.bottom > static_cast<LONG>(presentParameters.BackBufferHeight))
+        if (rect.bottom > static_cast<LONG>(backbufferHeight))
         {
-            rect.bottom = presentParameters.BackBufferHeight;
+            rect.bottom = backbufferHeight;
         }
 
         mRenderer->endScene();
@@ -288,8 +290,8 @@ EGLint SwapChain9::reset(DisplayD3D *displayD3D,
         SafeRelease(oldRenderTarget);
     }
 
-    mWidth        = presentParameters.BackBufferWidth;
-    mHeight       = presentParameters.BackBufferHeight;
+    mWidth        = backbufferWidth;
+    mHeight       = backbufferHeight;
     mSwapInterval = swapInterval;
 
     return EGL_SUCCESS;


### PR DESCRIPTION
As it turns out:
1. `mSwapChain->Present` fails on some machines, causing blackness. I could only repro with my VM. The resolution to this seems to be to present the device directly.
2. Presenting the device with a given source and destination rectangle causes things like never-ending minimisations of the game. Furthermore, _not_ doing this causes a black bar on the right side of the screen, which is worked around by this hack (from Google themselves): https://github.com/ppy/angle/blob/2a41552062097c7c9161a2d9d5df1638cf9b526e/src/libANGLE/renderer/d3d/d3d9/SwapChain9.cpp#L158-L171 However, it seems this needs the source and destination rectangles to be presented, which makes sense in hindsight. The solution to this seems to be to use the device for presentation in fullscreen mode and the swapchain for presentation in windowed mode.

I've tested this across 4 systems, and found that it gives the expected results on all.

The other changes in `SwapChain9::reset` are mostly reverts back to Google's code, of changes that existed similarly in the master-2016 branch.